### PR TITLE
Fix rounding of limit fee amount

### DIFF
--- a/src/main/java/com/algotrader/starkex/converters/StarkwareOrderConverter.java
+++ b/src/main/java/com/algotrader/starkex/converters/StarkwareOrderConverter.java
@@ -129,9 +129,9 @@ public class StarkwareOrderConverter {
     private BigInteger getStarkwareLimitFeeAmount(String limitFee, BigInteger quantumsAmountCollateral) {
         // Constrain the limit fee to six decimals of precision. The final fee amount must be rounded up.
         return new BigDecimal(limitFee)
-                .round(new MathContext(6, RoundingMode.DOWN))
+                .setScale(6, RoundingMode.DOWN)
                 .multiply(new BigDecimal(quantumsAmountCollateral))
-                .round(new MathContext(0, RoundingMode.UP))
+                .setScale(0, RoundingMode.UP)
                 .toBigInteger();
     }
 


### PR DESCRIPTION
BigDecimal.round() actually sets the number significant digits, not the number of digits (decimals). This causes an issue for small size orders like 0.0010 BTC.